### PR TITLE
Remove unnecessary UIKit import in OpenWhiskTests

### DIFF
--- a/OpenWhiskTests/OpenWhiskTests.swift
+++ b/OpenWhiskTests/OpenWhiskTests.swift
@@ -14,7 +14,6 @@
 * limitations under the License.
 */
 
-import UIKit
 import XCTest
 import OpenWhisk
 


### PR DESCRIPTION
This import is not needed here, and causes issues when trying to build the SDK for a CLI project.
